### PR TITLE
Allow supervision text content to update supervision caching

### DIFF
--- a/oscd-subscriber-later-binding.ts
+++ b/oscd-subscriber-later-binding.ts
@@ -593,6 +593,7 @@ export default class SubscriberLaterBinding extends LitElement {
     };
 
     const isSupervision = (element: Element) => {
+      if (!element) return false;
       if (['LN', 'DOI', 'DAI', 'Val'].includes(element.tagName)) {
         return (
           (element.tagName === 'LN' &&
@@ -632,9 +633,8 @@ export default class SubscriberLaterBinding extends LitElement {
         element = edit.node as Element;
       }
 
-      if (element) {
+      if (element && element.nodeType === Node.ELEMENT_NODE) {
         if (element.tagName === 'ExtRef') handleExtRef(element);
-
         if (element.tagName === 'FCDA') handleFCDA(element);
 
         // need to track before and after to ensure that appropriate values
@@ -643,6 +643,21 @@ export default class SubscriberLaterBinding extends LitElement {
           handleSupervision(element, true);
         if (isSupervision(element) && when === 'after' && !isRemove(edit))
           handleSupervision(element);
+      }
+
+      // handle text content of Val element
+      if (
+        (isRemove(edit) || isInsert(edit)) &&
+        edit.node.nodeType === Node.TEXT_NODE
+      ) {
+        const valElement = edit.node?.parentElement!;
+
+        if (isSupervision(valElement)) {
+          if (isSupervision(valElement) && when === 'before' && isRemove(edit))
+            handleSupervision(valElement, true);
+          if (isSupervision(valElement) && when === 'after' && !isRemove(edit))
+            handleSupervision(valElement);
+        }
       }
     });
   }

--- a/test/screenshots/baseline/goose subscriber view can change subscriptions by unsubscribing multiple ExtRefs with multiple supervision removal-Chromium.png
+++ b/test/screenshots/baseline/goose subscriber view can change subscriptions by unsubscribing multiple ExtRefs with multiple supervision removal-Chromium.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:40d3f7ba27921752b9418ae783e4ef9c2a2160a2086f65cf562dcd3694056c12
-size 195334
+oid sha256:271b960f189c27b5a19222c54650ba511c9ba271aac986b1bf20dc9da0ec26bd
+size 197756


### PR DESCRIPTION
A recent change to scl-lib meant that the caching in this plugin no longer functions correctly. This change should fix it.

It should probably have been picked up by tests and may have been except a change in the images for the tests resulted in many changes and may have masked it.

Closes #66 